### PR TITLE
chore: remove WeTransfer from Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ API | Description | Auth | HTTPS | CORS |
 | [OneDrive](https://dev.onedrive.com/) | File Sharing and Storage | `OAuth` | Yes | Unknown |
 | [Pastebin](https://pastebin.com/api/) | Plain Text Storage | `apiKey` | Yes | Unknown |
 | [Temporal](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud) | IPFS based file storage and sharing with optional IPNS naming | `apiKey` | Yes | No |
-| [WeTransfer](https://developers.wetransfer.com) | File Sharing | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 ### Continuous Integration


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request for this project!

To ensure your PR is dealt with swiftly please check the following:

- [x] Your submissions are formatted according to the guidelines in the [contributing guide](CONTRIBUTING.md)
- [ ] ~~Your additions are ordered alphabetically~~
- [ ] ~~Your submission has a useful description~~
- [ ] ~~The description does not end with punctuation~~
- [x] Each table column should be padded with one space on either side
- [x] You have searched the repository for any relevant issues or pull requests
- [ ] ~~Any category you are creating has the minimum requirement of 3 items~~
- [x] All changes have been [squashed][squash-link] into a single commit  

*struck lines entail a "Not Applicable" 

WeTransfer's Public API is no longer supported per their [developers page](https://developers.wetransfer.com/).
